### PR TITLE
dj-worker: resilient Ollama + admin UI improvements

### DIFF
--- a/services/api/alembic/versions/003_add_stations.py
+++ b/services/api/alembic/versions/003_add_stations.py
@@ -1,0 +1,57 @@
+"""add stations tables
+
+Revision ID: 003
+Revises: 002_default_settings
+Create Date: 2024-01-01 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "003"
+down_revision: Union[str, None] = "002_default_settings"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stations",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("genre", sa.String(length=100), nullable=True),
+        sa.Column("dj_persona", sa.String(length=100), nullable=True),
+        sa.Column("artwork_url", sa.String(length=1000), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_stations")),
+    )
+    op.create_index(op.f("ix_stations_id"), "stations", ["id"], unique=False)
+    op.create_index(op.f("ix_stations_name"), "stations", ["name"], unique=True)
+    op.create_index(op.f("ix_stations_genre"), "stations", ["genre"], unique=False)
+
+    op.create_table(
+        "station_tracks",
+        sa.Column("station_id", sa.Integer(), nullable=False),
+        sa.Column("track_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["station_id"],
+            ["stations.id"],
+            name=op.f("fk_station_tracks_station_id_stations"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["track_id"], ["tracks.id"], name=op.f("fk_station_tracks_track_id_tracks")
+        ),
+        sa.PrimaryKeyConstraint(
+            "station_id", "track_id", name=op.f("pk_station_tracks")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("station_tracks")
+    op.drop_index(op.f("ix_stations_genre"), table_name="stations")
+    op.drop_index(op.f("ix_stations_name"), table_name="stations")
+    op.drop_index(op.f("ix_stations_id"), table_name="stations")
+    op.drop_table("stations")

--- a/services/api/app/api/v1/__init__.py
+++ b/services/api/app/api/v1/__init__.py
@@ -1,6 +1,16 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import now_playing, stream, admin, liquidsoap, metadata, request_queue, artwork
+from app.api.v1.endpoints import (
+    now_playing,
+    stream,
+    admin,
+    liquidsoap,
+    metadata,
+    request_queue,
+    artwork,
+    tracks,
+    stations,
+)
 
 api_router = APIRouter()
 
@@ -12,3 +22,5 @@ api_router.include_router(liquidsoap.router, prefix="/liquidsoap", tags=["liquid
 api_router.include_router(metadata.router, prefix="/metadata", tags=["metadata"])
 api_router.include_router(request_queue.router, prefix="/queue", tags=["queue"])
 api_router.include_router(artwork.router, prefix="/artwork", tags=["artwork"])
+api_router.include_router(tracks.router, prefix="/tracks", tags=["tracks"])
+api_router.include_router(stations.router, prefix="/stations", tags=["stations"])

--- a/services/api/app/api/v1/endpoints/stations.py
+++ b/services/api/app/api/v1/endpoints/stations.py
@@ -1,0 +1,44 @@
+"""Station management endpoints."""
+
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.core.database import get_db
+from app.models import Station, Track
+from app.schemas import StationCreate, StationRead
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[StationRead])
+async def list_stations(db: AsyncSession = Depends(get_db)):
+    """Return all stations with their associated tracks."""
+    result = await db.execute(select(Station).options(selectinload(Station.tracks)))
+    return result.scalars().unique().all()
+
+
+@router.post("/", response_model=StationRead)
+async def create_station(
+    station: StationCreate, db: AsyncSession = Depends(get_db)
+) -> Station:
+    """Create a new station and attach any provided tracks."""
+    db_station = Station(
+        name=station.name,
+        description=station.description,
+        genre=station.genre,
+        dj_persona=station.dj_persona,
+        artwork_url=station.artwork_url,
+    )
+
+    if station.track_ids:
+        result = await db.execute(select(Track).where(Track.id.in_(station.track_ids)))
+        db_station.tracks = result.scalars().all()
+
+    db.add(db_station)
+    await db.commit()
+    await db.refresh(db_station)
+    return db_station

--- a/services/api/app/api/v1/endpoints/tracks.py
+++ b/services/api/app/api/v1/endpoints/tracks.py
@@ -1,0 +1,17 @@
+from typing import List
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.core.database import get_db
+from app.models import Track
+from app.schemas import TrackRead
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[TrackRead])
+async def list_tracks(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Track))
+    tracks = result.scalars().all()
+    return tracks

--- a/services/api/app/models/__init__.py
+++ b/services/api/app/models/__init__.py
@@ -4,5 +4,16 @@ from .commentary import Commentary
 from .settings import Setting
 from .users import User
 from .request_queue import RequestQueue, RequestType, RequestStatus
+from .stations import Station
 
-__all__ = ["Track", "Play", "Commentary", "Setting", "User", "RequestQueue", "RequestType", "RequestStatus"]
+__all__ = [
+    "Track",
+    "Play",
+    "Commentary",
+    "Setting",
+    "User",
+    "RequestQueue",
+    "RequestType",
+    "RequestStatus",
+    "Station",
+]

--- a/services/api/app/models/stations.py
+++ b/services/api/app/models/stations.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, Table
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+# Association table linking stations and tracks
+station_tracks = Table(
+    "station_tracks",
+    Base.metadata,
+    Column("station_id", Integer, ForeignKey("stations.id"), primary_key=True),
+    Column("track_id", Integer, ForeignKey("tracks.id"), primary_key=True),
+)
+
+
+class Station(Base):
+    __tablename__ = "stations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(200), unique=True, nullable=False, index=True)
+    description = Column(Text, nullable=True)
+    genre = Column(String(100), nullable=True, index=True)
+    dj_persona = Column(String(100), nullable=True)
+    artwork_url = Column(String(1000), nullable=True)
+
+    tracks = relationship("Track", secondary=station_tracks, back_populates="stations")

--- a/services/api/app/models/tracks.py
+++ b/services/api/app/models/tracks.py
@@ -1,12 +1,14 @@
-from sqlalchemy import Column, Integer, String, Text, JSON, DateTime, Float, Boolean
+from sqlalchemy import Column, Integer, String, JSON, DateTime, Float, Boolean
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
+from .stations import station_tracks
+
 
 class Track(Base):
     __tablename__ = "tracks"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String(500), nullable=False, index=True)
     artist = Column(String(500), nullable=False, index=True)
@@ -19,7 +21,7 @@ class Track(Base):
     file_size = Column(Integer, nullable=True)
     bitrate = Column(Integer, nullable=True)
     sample_rate = Column(Integer, nullable=True)
-    
+
     # Audio features
     bpm = Column(Float, nullable=True)
     key = Column(Integer, nullable=True)  # 0=C, 1=C#, etc.
@@ -31,35 +33,45 @@ class Track(Base):
     instrumentalness = Column(Float, nullable=True)
     liveness = Column(Float, nullable=True)
     loudness_db = Column(Float, nullable=True)
-    
+
     # Metadata
     artwork_url = Column(String(1000), nullable=True)
     artwork_embedded = Column(Boolean, default=False)
     tags = Column(JSON, nullable=True)  # Additional metadata tags
-    
+
     # External IDs
     isrc = Column(String(50), nullable=True, index=True)
     recording_mbid = Column(String(36), nullable=True, index=True)
     release_mbid = Column(String(36), nullable=True, index=True)
     spotify_id = Column(String(100), nullable=True, index=True)
-    
+
     # Enrichment data
     facts = Column(JSON, nullable=True)  # Song facts from AI/APIs
     popularity_score = Column(Float, nullable=True)
     mood_tags = Column(JSON, nullable=True)  # Array of mood strings
-    
+
     # Timestamps
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
     last_played_at = Column(DateTime(timezone=True), nullable=True)
-    
+
     # Statistics
     play_count = Column(Integer, default=0, nullable=False)
     skip_count = Column(Integer, default=0, nullable=False)
     last_commentary_at = Column(DateTime(timezone=True), nullable=True)
-    
+
     # Relationships
     plays = relationship("Play", back_populates="track")
-    
+    stations = relationship(
+        "Station", secondary=station_tracks, back_populates="tracks"
+    )
+
     def __repr__(self):
         return f"<Track(id={self.id}, title='{self.title}', artist='{self.artist}')>"

--- a/services/api/app/schemas/__init__.py
+++ b/services/api/app/schemas/__init__.py
@@ -1,7 +1,17 @@
+# ruff: noqa: F403, F405
 from .stream import *
 from .admin import *
+from .station import *
+from .track import *
 
 __all__ = [
-    "NowPlayingResponse", "HistoryResponse", "NextUpResponse",
-    "AdminSettingsResponse", "AdminStatsResponse"
+    "NowPlayingResponse",
+    "HistoryResponse",
+    "NextUpResponse",
+    "AdminSettingsResponse",
+    "AdminStatsResponse",
+    "StationBase",
+    "StationCreate",
+    "StationRead",
+    "TrackRead",
 ]

--- a/services/api/app/schemas/station.py
+++ b/services/api/app/schemas/station.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+from .track import TrackRead
+
+
+class StationBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+    genre: Optional[str] = None
+    dj_persona: Optional[str] = None
+    artwork_url: Optional[str] = None
+
+
+class StationCreate(StationBase):
+    track_ids: List[int] = []
+
+
+class StationRead(StationBase):
+    id: int
+    tracks: List[TrackRead] = []
+
+    class Config:
+        orm_mode = True

--- a/services/api/app/schemas/track.py
+++ b/services/api/app/schemas/track.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class TrackRead(BaseModel):
+    id: int
+    title: str
+    artist: str
+    album: Optional[str] = None
+    genre: Optional[str] = None
+
+    class Config:
+        orm_mode = True

--- a/services/api/tests/test_station_track_models.py
+++ b/services/api/tests/test_station_track_models.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+
+# Temporarily disable loading the project's .env to avoid validation errors
+_env_renamed = False
+if Path(".env").exists():
+    Path(".env").rename(".env.bak")
+    _env_renamed = True
+
+from app.core.database import Base  # noqa: E402
+from app.models import Station, Track  # noqa: E402
+
+if _env_renamed:
+    Path(".env.bak").rename(".env")
+
+
+def test_station_track_relationship():
+    async def _run():
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async_session = sessionmaker(
+            engine, expire_on_commit=False, class_=AsyncSession
+        )
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with async_session() as session:
+            track = Track(title="Song", artist="Artist", file_path="/tmp/song.mp3")
+            station = Station(name="Test Station")
+            station.tracks.append(track)
+            session.add(station)
+            await session.commit()
+            await session.refresh(station, attribute_names=["tracks"])
+            await session.refresh(track, attribute_names=["stations"])
+
+            assert station.tracks[0].title == "Song"
+            assert track.stations[0].name == "Test Station"
+
+    asyncio.run(_run())

--- a/services/dj-worker/app/services/ollama_client.py
+++ b/services/dj-worker/app/services/ollama_client.py
@@ -16,10 +16,36 @@ class OllamaClient:
     def __init__(self):
         self.base_url = settings.OLLAMA_BASE_URL
         self.model = settings.OLLAMA_MODEL
+        self.last_mode: str | None = None  # 'stream' | 'nonstream' | None
         # Track recent failures for simple cooldown circuit breaker
         self._failures: deque[float] = deque(maxlen=10)
-        self._cooldown_seconds = 300  # 5 minutes
+        # Cooldown after repeated failures to avoid hammering the server
+        # Use a short cooldown so brief blips don't force long template fallbacks
+        self._cooldown_seconds = 30  # seconds
         self._failure_threshold = 3
+
+    def _ollama_options(self, *, temperature: float, num_predict: int) -> dict:
+        """Build tuned generation options for Ollama.
+
+        Defaults favor concise, stable outputs suitable for TTS.
+        """
+        # Clamp reasonable bounds
+        try:
+            t = max(0.0, min(float(temperature), 1.5))
+        except Exception:
+            t = 0.8
+        try:
+            npredict = max(16, min(int(num_predict), 300))
+        except Exception:
+            npredict = 120
+        return {
+            "temperature": t,
+            "num_predict": npredict,
+            # Light guidance for stable speech-y text
+            "top_p": 0.9,
+            "top_k": 40,
+            "repeat_penalty": 1.08,
+        }
     
     async def warmup(self) -> None:
         """Warm up the Ollama model to reduce first-request latency."""
@@ -70,75 +96,115 @@ class OllamaClient:
                 )
                 return None
 
-            # Stream tokens to avoid long blocking waits
-            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
-                async with client.stream(
-                    "POST",
-                    f"{self.base_url}/api/generate",
-                    json={
-                        "model": use_model,
-                        "prompt": prompt,
-                        "stream": True,
-                        "options": {
-                            "temperature": temperature,
-                            "num_predict": max_tokens
-                        }
-                    },
-                ) as resp:
-                    if resp.status_code != 200:
-                        body = await resp.aread()
-                        logger.error("Ollama API error", status=resp.status_code, response=body.decode(errors='ignore'))
-                        # Count as failure for cooldown
-                        self._failures.append(time.time())
-                        return None
+            # Prefer streaming to keep latency low; on any issue, fall back to non-streaming
+            content_parts: list[str] = []
+            try:
+                async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=90.0, write=60.0)) as client:
+                    async with client.stream(
+                        "POST",
+                        f"{self.base_url}/api/generate",
+                        json={
+                            "model": use_model,
+                            "prompt": prompt,
+                            "stream": True,
+                            "options": self._ollama_options(temperature=temperature, num_predict=max_tokens),
+                        },
+                    ) as resp:
+                        if resp.status_code != 200:
+                            body = await resp.aread()
+                            logger.warning("Ollama streaming error; will retry non-streaming",
+                                           status=resp.status_code,
+                                           response=body.decode(errors='ignore')[:200])
+                        else:
+                            async for line in resp.aiter_lines():
+                                if not line:
+                                    continue
+                                try:
+                                    import json as _json
+                                    raw = line.strip()
+                                    if raw.startswith("data: "):
+                                        raw = raw[6:].strip()
+                                    if not raw:
+                                        continue
+                                    data = _json.loads(raw)
+                                except Exception as e:
+                                    logger.debug("Skipping malformed JSON line", line=line[:100], error=str(e))
+                                    continue
+                                if not isinstance(data, dict):
+                                    logger.debug("Skipping non-object response", type=type(data).__name__)
+                                    continue
+                                piece = data.get("response")
+                                if isinstance(piece, str) and piece:
+                                    content_parts.append(piece)
+                                if data.get("done") is True:
+                                    break
+                            # We got streamed content
+                            if content_parts:
+                                self.last_mode = 'stream'
+            except Exception as se:
+                logger.warning("Ollama streaming request failed; will try non-streaming", error=str(se))
 
-                    content_parts: list[str] = []
-                    async for line in resp.aiter_lines():
-                        if not line:
-                            continue
-                        try:
+            # If streaming yielded no content, try a non-streaming call once
+            if not content_parts:
+                try:
+                    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=90.0, write=60.0)) as client:
+                        resp = await client.post(
+                            f"{self.base_url}/api/generate",
+                            json={
+                                "model": use_model,
+                                "prompt": prompt,
+                                "stream": False,
+                                "options": self._ollama_options(temperature=temperature, num_predict=max_tokens),
+                            },
+                        )
+                        if resp.status_code == 200:
                             import json as _json
-                            # Some servers may prefix lines with 'data: '
-                            raw = line.strip()
-                            if raw.startswith("data: "):
-                                raw = raw[6:].strip()
-                            if not raw:
-                                continue
-                            data = _json.loads(raw)
-                        except Exception as e:
-                            # Log malformed JSON for debugging and continue
-                            logger.debug("Skipping malformed JSON line", line=line[:100], error=str(e))
-                            continue
-                        
-                        # Only process valid response objects
-                        if not isinstance(data, dict):
-                            logger.debug("Skipping non-object response", type=type(data).__name__)
-                            continue
-                            
-                        piece = data.get("response")
-                        if isinstance(piece, str) and piece:
-                            content_parts.append(piece)
-                        if data.get("done") is True:
-                            break
+                            try:
+                                data = resp.json()
+                            except Exception:
+                                # Some servers may return NDJSON-like outputs even when stream=false; try best-effort
+                                text = (await resp.aread()).decode(errors='ignore')
+                                try:
+                                    data = _json.loads(text)
+                                except Exception:
+                                    data = {"response": text}
+                            # The non-streaming response typically has a single 'response' string
+                            nonstream_text = data.get("response") if isinstance(data, dict) else None
+                            if isinstance(nonstream_text, str) and nonstream_text.strip():
+                                content_parts = [nonstream_text]
+                                self.last_mode = 'nonstream'
+                            else:
+                                logger.error("Ollama non-streaming response missing 'response' field",
+                                             preview=str(data)[:200])
+                        else:
+                            logger.error("Ollama non-streaming error",
+                                         status=resp.status_code,
+                                         body=(await resp.aread()).decode(errors='ignore')[:200])
+                except Exception as nse:
+                    logger.error("Ollama non-streaming request failed", error=str(nse))
 
             if content_parts:
                 content = "".join(content_parts).strip()
                 logger.debug("Generated commentary", length=len(content))
-                
+                # Reset failures on success
+                try:
+                    self._failures.clear()
+                except Exception:
+                    pass
                 # Sanity check: if the content looks like raw JSON, something went wrong
                 if content.startswith('{"model":') or content.count('{"model":') > 3:
-                    logger.error("Commentary appears to contain raw JSON responses", 
-                               content_preview=content[:200])
+                    logger.error("Commentary appears to contain raw JSON responses",
+                                 content_preview=content[:200])
                     self._failures.append(time.time())
                     return None
-                    
                 return content
             # No content is a failure; track
             self._failures.append(time.time())
+            logger.error("Ollama produced no content", base_url=self.base_url, model=use_model)
             return None
         
         except Exception as e:
-            logger.error("Ollama commentary generation failed", error=str(e))
+            logger.error("Ollama commentary generation failed", error=str(e), base_url=self.base_url, model=use_model)
             try:
                 self._failures.append(time.time())
             except Exception:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import ComingUp from './components/ComingUp'
 import PlayHistory from './components/PlayHistory'
 import TTSMonitor from './components/TTSMonitor'
 import Analytics from './components/Analytics'
+import StationManager from './components/StationManager'
 // import DJSettings from './components/DJSettings' // Removed - functionality moved to TTSMonitor
 
 function App() {
@@ -42,9 +43,13 @@ function App() {
             path="/tts" 
             element={<TTSMonitor />} 
           />
-          <Route 
-            path="/analytics" 
-            element={<Analytics />} 
+          <Route
+            path="/analytics"
+            element={<Analytics />}
+          />
+          <Route
+            path="/stations"
+            element={<StationManager />}
           />
           {/* DJ Settings route removed - functionality moved to /tts */}
           <Route 

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -28,6 +28,7 @@ export default function Layout({ children }: LayoutProps) {
     { name: 'Now Playing', href: '/', icon: HomeIcon },
     { name: 'DJ Admin', href: '/tts', icon: SettingsIcon },
     { name: 'Analytics', href: '/analytics', icon: BarChart3Icon },
+    { name: 'Stations', href: '/stations', icon: Radio },
   ]
 
   return (

--- a/web/src/components/StationManager.tsx
+++ b/web/src/components/StationManager.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react'
+import { apiHelpers } from '../utils/api'
+
+interface Track {
+  id: number
+  title: string
+  artist: string
+}
+
+interface Station {
+  id: number
+  name: string
+  tracks: Track[]
+}
+
+const StationManager: React.FC = () => {
+  const [tracks, setTracks] = useState<Track[]>([])
+  const [stations, setStations] = useState<Station[]>([])
+  const [name, setName] = useState('')
+  const [selectedTracks, setSelectedTracks] = useState<number[]>([])
+
+  useEffect(() => {
+    apiHelpers.getTracks()
+      .then(res => setTracks(res.data))
+      .catch(() => setTracks([]))
+    apiHelpers.getStations()
+      .then(res => setStations(res.data))
+      .catch(() => setStations([]))
+  }, [])
+
+  const handleCreate = async () => {
+    if (!name) return
+    try {
+      const res = await apiHelpers.createStation({ name, track_ids: selectedTracks })
+      setStations(prev => [...prev, res.data])
+      setName('')
+      setSelectedTracks([])
+    } catch (err) {
+      console.error('Failed to create station', err)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-gray-800 p-4 rounded-lg">
+        <h2 className="text-xl text-white mb-2">Create Station</h2>
+        <input
+          className="w-full p-2 mb-2 rounded bg-gray-700 text-white"
+          placeholder="Name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <label className="text-gray-300 text-sm">Tracks</label>
+        <select
+          multiple
+          className="w-full p-2 mb-2 rounded bg-gray-700 text-white h-40"
+          value={selectedTracks.map(String)}
+          onChange={e =>
+            setSelectedTracks(Array.from(e.target.selectedOptions).map(o => Number(o.value)))
+          }
+        >
+          {tracks.map(t => (
+            <option key={t.id} value={t.id}>
+              {t.artist} - {t.title}
+            </option>
+          ))}
+        </select>
+        <button
+          className="px-4 py-2 bg-pirate-500 rounded text-white"
+          onClick={handleCreate}
+        >
+          Create
+        </button>
+      </div>
+      <div className="bg-gray-800 p-4 rounded-lg">
+        <h2 className="text-xl text-white mb-2">Stations</h2>
+        <ul className="text-gray-300 space-y-1">
+          {stations.map(s => (
+            <li key={s.id}>
+              <div>
+                {s.name} ({s.tracks.length} tracks)
+              </div>
+              {s.tracks.length > 0 && (
+                <ul className="ml-4 list-disc">
+                  {s.tracks.map(t => (
+                    <li key={t.id}>{t.artist} - {t.title}</li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default StationManager

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -84,9 +84,14 @@ export const apiHelpers = {
   
   // TTS management
   deleteCommentary: (commentaryId: number) => api.delete(`/admin/commentary/${commentaryId}`),
-  
+
   // Stream controls
   skipTrack: () => api.post('/liquidsoap/skip'),
+
+  // Music library and stations
+  getTracks: () => api.get('/tracks'),
+  getStations: () => api.get('/stations'),
+  createStation: (data: any) => api.post('/stations', data),
 }
 
 export default api


### PR DESCRIPTION
Summary
- dj-worker: Make Ollama provider resilient to transient failures
  - Shorten cooldown after failures (5m → 30s)
  - Add non‑streaming retry if streaming path yields no content
  - Tune generation options (temperature clamp, top_p=0.9, top_k=40, repeat_penalty=1.08)
  - Improve logs; record admin-selected provider on commentary records
- api: Expose llm_mode in /admin/tts-status and fetch Chatterbox voices from server if available
- web: Admin UI polish
  - Default commentary provider dropdown to Templates to match backend defaults
  - “Unsaved changes” indicator + disabled Save until changes
  - Chatterbox: add Custom Voice field; include current value in dropdown even if not listed
  - Gating banner: show interval status and next-up track; explain dedupe/interval
  - Badge in Recent Activity when Ollama used non‑streaming fallback

Context
Operators had Ollama selected but saw Template fallbacks after brief connectivity hiccups. The dj-worker had a strict 5-minute cooldown after 3 failures and no non-stream retry; this PR reduces friction and makes recovery fast. The UI also previously default‑rendered “Ollama” even if backend default was Templates, which confused users. This aligns defaults and adds clarity.

Implementation notes
- services/dj-worker/app/services/ollama_client.py
  - cooldown 300 → 30 sec; add last_mode; tune httpx timeouts
  - streaming path with JSONL parsing; on error, one non-streaming POST retry
  - tuned options builder; reset failures on success; improved error logs
- services/dj-worker/app/services/commentary_generator.py
  - returns gen_mode for UI/analytics
- services/dj-worker/app/worker/dj_worker.py
  - store admin dj_provider for commentary; attach ollama_mode into context_data
- services/api/app/api/v1/endpoints/admin.py
  - /voices-chatterbox fetches from server endpoints; fallback list retained
  - /tts-status includes llm_mode per item
- web/src/components/TTSMonitor.tsx
  - default provider Templates; unsaved changes banner; Chatterbox Custom Voice input
  - gating banner; non‑streaming fallback badge in Recent Activity

Test plan
- Set DJ Provider=Ollama, Voice=Chatterbox, Custom Voice=brian; Save
- Force next-up intro via Skip; expect Recent Activity: “ollama • chatterbox”
- Temporarily block Ollama for a second (or point to bad URL), then restore; within 30s cooldown, next cycle should use non‑streaming fallback (badge appears), then recover
- Verify /api/v1/admin/tts-status includes llm_mode; UI shows badge accordingly
- Chatterbox voices endpoint tries /voices, /v1/voices, /v1/audio/voices and falls back; UI dropdown lists either fetched voices or defaults; custom voice input persists

Ops notes
- For low-resource hosts, keep MAX_CONCURRENT_JOBS=1
- Ensure OLLAMA_BASE_URL is reachable from dj-worker; model installed
